### PR TITLE
Small changes to fix build on my machine

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ args = { path = "src/args" }
 function = { path = "src/function" }
 getopts = "0.2.*"
 rand = "0.3.*"
-time = "0.3.*"
+time = "0.1.*"
 threadpool = "1.3.*"
 num_cpus = "0.*"
 

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
 
 # Set paths to point to locally built requirements first
-export PATH := ${CURDIR}/requirements/bin:${PATH}
+#export PATH := ${CURDIR}/requirements/bin:${PATH}
 export LD_LIBRARY_PATH := $(CURDIR)/requirements/lib:${LD_LIBRARY_PATH}
 export CPLUS_INCLUDE_PATH := $(CURDIR)/requirements/include:${CPLUS_INCLUDE_PATH}
 export LIBRARY_PATH := $(CURDIR)/requirements/lib:${LIBRARY_PATH}
 
+# override
+CXXFLAGS=--std=c++14
 
 all: bin/gelpia src/func/comp_comm.sh bin/build_func.sh bin/gaol_repl
 	@cargo build --release


### PR DESCRIPTION
* Reverted version change of `time` crate that broke the rust build
* Added C++14 flag to prevent compilation errors caused by default newer C++ (on my machine)
* Commented out PATH because I installed rust differently

The PATH change I'm the least sure of.